### PR TITLE
Made output similar to Gogs bot and verify payload if token is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*$py.class
+.idea/

--- a/webhook.py
+++ b/webhook.py
@@ -1,26 +1,48 @@
-from flask import *
-import telegram
+import hashlib
+import hmac
 import html
 import json
 import os
 
+import telegram
+from flask import *
+
 app = Flask(__name__)
 bot = telegram.Bot(token=os.environ.get("TOKEN"))
+webhook_secret = os.environ.get("WEBHOOK_SECRET")
+
+
+def is_signature_valid(request_signature, data):
+    data_signature = hmac.new(webhook_secret.encode('utf-8'), data, hashlib.sha1).hexdigest()
+    return hmac.compare_digest(data_signature, request_signature)
+
 
 @app.route("/gogs/<chat_id>", methods=["POST"])
 def process(chat_id):
+    if webhook_secret:
+        if "X-Hub-Signature" not in request.headers or not is_signature_valid(
+                request.headers.get("X-Hub-Signature").split('=')[1], request.data):
+            return "", 403
+
     data = json.loads(request.data.decode())
+    if "commits" not in data:
+        return ""
+
+    text = "[<a href=\"{repo_url}\">{repo}</a>:<a href=\"{compare_url}\">{branch}</a>]: {count} new commit{s}\n".format(
+            repo_url=data["repository"]["url"],
+            repo=data["repository"]["full_name"],
+            compare_url=data["compare"],
+            branch=data["ref"].split("/")[-1],
+            count=len(data["commits"]),
+            s="s" if len(data["commits"]) > 1 else ""
+    )
     for commit in reversed(data["commits"]):
-        bot.sendMessage(
-            chat_id=chat_id,
-            text="<b>{0}</b> hat gerade <a href='{1}'>{2}</a> in <b>{3}</b> commited:\n<pre>{4}</pre>".format(
-                commit["author"]["name"],
-                commit["url"],
-                commit["id"],
-                data["repository"]["name"],
-                html.escape(commit["message"])
-            ),
-            parse_mode=telegram.ParseMode.HTML,
-            disable_web_page_preview=True
+        text += "[<a href=\"{url}\">{sha}</a>] <code>{msg}</code> - {author}\n".format(
+                url=commit["url"],
+                sha=commit["id"][:7],
+                msg=html.escape(commit["message"]),
+                author=html.escape(commit["author"]["name"])
         )
+
+    bot.sendMessage(chat_id=chat_id, text=text, parse_mode=telegram.ParseMode.HTML, disable_web_page_preview=True)
     return ""


### PR DESCRIPTION
This will change the output to be similar to the Gogs bot. It's more compact and writes all commits into one message instead of sending one for each commit.

Also as a bonus, you can now set the env variable "WEBHOOK_SECRET" and it will verify the payload before processing it.